### PR TITLE
Ignore `zsh/env.zsh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vim/viminfo
 .vim/swaps/*
 .vim/undo
+
+zsh/env.zsh


### PR DESCRIPTION
I never added this file to my gitignore, and I paid the price when I
accicentally pushed an AWS keypair to GitHub.