### PR TITLE
Add `dc` alias

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -1,3 +1,4 @@
 alias git=hub
 alias ls="ls -G"
 alias ll="ls -lra"
+alias dc="docker-compose"


### PR DESCRIPTION
For `docker-compose`, which I always spell wrong.